### PR TITLE
在ServerModel关闭时，需要释放全局变量

### DIFF
--- a/FunGame.Server/Models/ServerModel.cs
+++ b/FunGame.Server/Models/ServerModel.cs
@@ -28,8 +28,8 @@ namespace Milimoe.FunGame.Server.Model
             get => _Room;
             set => _Room = value;
         }
-        public MySQLHelper? SQLHelper { get; }
-        public MailSender? MailSender { get; }
+        public MySQLHelper? SQLHelper => _SQLHelper;
+        public MailSender? MailSender => _MailSender;
         public bool IsDebugMode { get; }
 
         /**
@@ -42,6 +42,8 @@ namespace Milimoe.FunGame.Server.Model
         private User _User = General.UnknownUserInstance;
         private Room _Room = General.HallInstance;
         private string _ClientName = "";
+        public MySQLHelper? _SQLHelper = null;
+        public MailSender? _MailSender = null;
 
         private Guid CheckLoginKey = Guid.Empty;
         private int FailedTimes = 0; // 超过一定次数断开连接
@@ -61,8 +63,8 @@ namespace Milimoe.FunGame.Server.Model
             _Running = running;
             Token = socket.Token;
             this.IsDebugMode = isDebugMode;
-            if (Config.SQLMode) SQLHelper = new(this);
-            MailSender = SmtpHelper.GetMailSender();
+            if (Config.SQLMode) _SQLHelper = new(this);
+            _MailSender = SmtpHelper.GetMailSender();
             DataRequestController = new(this);
         }
 
@@ -629,7 +631,9 @@ namespace Milimoe.FunGame.Server.Model
             try
             {
                 SQLHelper?.Close();
+                _SQLHelper = null;
                 MailSender?.Dispose();
+                _MailSender = null;
                 Socket?.Close();
                 _Socket = null;
                 _Running = false;


### PR DESCRIPTION
解决此问题：
2023/12/29 3:12:03 [Api] 米粒的糖果屋：SQLQuery -> Select * From Users Where Username = 'Mili'
2023/12/29 3:12:03 [Error] 米粒的糖果屋：ADP_ConnectionRequired_Fill
   at System.Data.Common.DbDataAdapter.GetConnection3(IDbCommand command, String method)
   at System.Data.Common.DbDataAdapter.FillInternal(DataSet dataset, DataTable[] datatables, Int32 startRecord, Int32 maxRecords, String srcTable, IDbCommand command, CommandBehavior behavior)
   at System.Data.Common.DbDataAdapter.Fill(DataSet dataSet, Int32 startRecord, Int32 maxRecords, String srcTable, IDbCommand command, CommandBehavior behavior)
   at System.Data.Common.DbDataAdapter.Fill(DataSet dataSet)
   at Milimoe.FunGame.Server.Utility.MySQLManager.ExecuteDataSet(MySQLHelper Helper, SQLResult& Result, Int32& Rows) in C:\milimoe\FunGame.Server\FunGame.Server\Utilities\MySQLManager.cs:line 61